### PR TITLE
Turn was_published_recently into property

### DIFF
--- a/books/models.py
+++ b/books/models.py
@@ -15,7 +15,7 @@ class Book(models.Model):
 
     def __str__(self):
         return self.title
-    
+
     @property
     def was_published_recently(self):
         return self.pub_date >= timezone.now() - datetime.timedelta(days=100)

--- a/books/models.py
+++ b/books/models.py
@@ -15,6 +15,7 @@ class Book(models.Model):
 
     def __str__(self):
         return self.title
-
+    
+    @property
     def was_published_recently(self):
         return self.pub_date >= timezone.now() - datetime.timedelta(days=100)


### PR DESCRIPTION
Just demonstrating the python decorator syntax. You can use the `@property` decorator to turn a method into a computed property.

Before change:

```python
book = Book(pub_date=datetime.now())
if book.was_published_recently():
  print('Published Recently')
```

After making it a property, it's just a computed property instead of a method call

```python
book = Book(pub_date=datetime.now())
if book.was_published_recently:
  print('Published Recently')
```

It's a minor but useful thing, especially if you start metaprogramming with the `__getattr__` and `__getattribute__` dunder methods. Python decorators are really powerful. You can also use them to define getters and setters on a computed property.

JS Equivalent:

```js
class Book {
  get wasPublishedRecently () {
    return this.pubDate >= someDate
  }
}
```

