### PR TITLE
Json api integration improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 env/*
+.idea

--- a/books/models.py
+++ b/books/models.py
@@ -8,10 +8,16 @@ class Genre(models.Model):
     def __str__(self):
         return self.name
 
+    class JSONAPIMeta:
+        resource_name = "genres"
+
 class Author(models.Model):
     name = models.CharField(max_length=200)
     def __str__(self):
         return self.name
+
+    class JSONAPIMeta:
+        resource_name = "authors"
 
 class Book(models.Model):
     author = models.ForeignKey(Author, on_delete=models.CASCADE, related_name='books')
@@ -21,6 +27,9 @@ class Book(models.Model):
 
     def __str__(self):
         return self.title
+
+    class JSONAPIMeta:
+        resource_name = "books"
 
     @property
     def was_published_recently(self):

--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -12,8 +12,17 @@ export default DS.JSONAPIAdapter.extend({
     }
   }),
   host: ENV.apiHost,
-  buildURL: function(type, id, record) {
-     //call the default buildURL and then append a slash
-     return this._super(type, id, record) + '/';
-   }
-});
+  buildURL: function (type, id, record) {
+    // call the default buildURL and then append a slash
+    return this._super(type, id, record) + '/'
+  },
+  handleResponse: function (status, headers, payload) {
+    if (status >= 400 && status < 500 && payload.errors) {
+      if (payload.errors[0].code === 'AUTHORIZATION_REQUIRED') {
+        return get(this, 'session').logout()
+      }
+      return new DS.InvalidError(payload.errors)
+    }
+    return this._super(...arguments)
+  }
+})

--- a/client/app/adapters/application.js
+++ b/client/app/adapters/application.js
@@ -1,8 +1,18 @@
-import DS from 'ember-data';
-import ENV from 'client/config/environment';
+import DS from 'ember-data'
+import Ember from 'ember'
+import ENV from 'client/config/environment'
+
+const {computed, inject, get} = Ember
+
 export default DS.JSONAPIAdapter.extend({
-   host: ENV.apiHost,
-   buildURL: function(type, id, record) {
+  session: inject.service(),
+  headers: computed('session.token', function () {
+    return {
+      Authorization: 'Token ' + get(this, 'session.token')
+    }
+  }),
+  host: ENV.apiHost,
+  buildURL: function(type, id, record) {
      //call the default buildURL and then append a slash
      return this._super(type, id, record) + '/';
    }

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -1,18 +1,23 @@
-import Ember from 'ember';
-import Resolver from './resolver';
-import loadInitializers from 'ember-load-initializers';
-import config from './config/environment';
+import Ember from 'ember'
+import Resolver from './resolver'
+import loadInitializers from 'ember-load-initializers'
+import config from './config/environment'
+import AuthenticatedRouteMixin from 'client/mixins/authenticated-route-mixin'
 
-let App;
+let App
 
-Ember.MODEL_FACTORY_INJECTIONS = true;
+Ember.MODEL_FACTORY_INJECTIONS = true
 
 App = Ember.Application.extend({
   modulePrefix: config.modulePrefix,
   podModulePrefix: config.podModulePrefix,
   Resolver
-});
+})
 
-loadInitializers(App, config.modulePrefix);
+loadInitializers(App, config.modulePrefix)
 
-export default App;
+// Ember.UnprotectedRoute = Ember.Route
+// Ember.Route = Ember.Route.extend(AuthenticatedRouteMixin)
+
+export default App
+

--- a/client/app/components/add-edit-author/template.hbs
+++ b/client/app/components/add-edit-author/template.hbs
@@ -1,0 +1,7 @@
+{{mediasuite-input
+  label='Author Name'
+  value=author.name
+  update=(action (mut author.name))
+}}
+
+<button {{action saveAuthor author}}>Save Author</button>

--- a/client/app/components/add-edit-author/template.hbs
+++ b/client/app/components/add-edit-author/template.hbs
@@ -2,6 +2,7 @@
   label='Author Name'
   value=author.name
   update=(action (mut author.name))
+  errors=author.errors.name
 }}
 
 <button {{action saveAuthor author}}>Save Author</button>

--- a/client/app/components/login-form/component.js
+++ b/client/app/components/login-form/component.js
@@ -1,0 +1,12 @@
+import Ember from 'ember'
+const { get } = Ember
+
+export default Ember.Component.extend({
+  username: '',
+  password: '',
+  actions: {
+    login () {
+      get(this, 'login')(get(this, 'username'), get(this, 'password'))
+    }
+  }
+})

--- a/client/app/components/login-form/template.hbs
+++ b/client/app/components/login-form/template.hbs
@@ -1,0 +1,14 @@
+{{mediasuite-input
+  label='Username'
+  value=username
+  update=(action (mut username))
+}}
+
+{{mediasuite-input
+  type='password'
+  label='Password'
+  value=password
+  update=(action (mut password))
+}}
+
+<button {{action 'login'}}>Login</button>

--- a/client/app/mixins/authenticated-route-mixin.js
+++ b/client/app/mixins/authenticated-route-mixin.js
@@ -1,0 +1,18 @@
+import Ember from 'ember'
+const {get, set, inject} = Ember
+
+export default Ember.Mixin.create({
+  flashMessages: inject.service(),
+  beforeModel (transition) {
+    return get(this, 'session.currentUser').then(() => {
+      if (!get(this, 'session.isAuthenticated')) {
+        set(this, 'session.returnTo', transition.intent.url)
+        transition.abort()
+        get(this, 'flashMessages.danger')('You must be logged in to access that')
+        get(this, 'session').login()
+      } else {
+        return this._super(...arguments)
+      }
+    })
+  }
+})

--- a/client/app/router.js
+++ b/client/app/router.js
@@ -1,14 +1,16 @@
-import Ember from 'ember';
-import config from './config/environment';
+import Ember from 'ember'
+import config from './config/environment'
 
 const Router = Ember.Router.extend({
   location: config.locationType,
   rootURL: config.rootURL
-});
+})
 
-Router.map(function() {
-  this.route('books');
-  this.route('authors');
-});
+Router.map(function () {
+  this.route('login', {path: '/'})
+  this.route('index')
+  this.route('books')
+  this.route('authors')
+})
 
-export default Router;
+export default Router

--- a/client/app/routes/authors.js
+++ b/client/app/routes/authors.js
@@ -1,7 +1,19 @@
-import Ember from 'ember';
+import Ember from 'ember'
+const { get } = Ember
 
 export default Ember.Route.extend({
   model () {
-    return this.get('store').findAll('author', {include: 'books,books.genre'});
+    return {
+      authors: this.get('store').findAll('author', {include: 'books,books.genre'}),
+      newAuthor: this.get('store').createRecord('author')
+    }
+  },
+
+  actions: {
+    saveAuthor (author) {
+      author.save()
+        .then(() => alert('success'))
+        .catch(e => alert('failed with ', e))
+    }
   }
-});
+})

--- a/client/app/routes/authors.js
+++ b/client/app/routes/authors.js
@@ -1,5 +1,4 @@
 import Ember from 'ember'
-const { get } = Ember
 
 export default Ember.Route.extend({
   model () {

--- a/client/app/routes/books.js
+++ b/client/app/routes/books.js
@@ -1,7 +1,7 @@
-import Ember from 'ember';
+import Ember from 'ember'
 
 export default Ember.Route.extend({
   model () {
-    return this.get('store').findAll('book', {include: 'author'});
+    return this.get('store').findAll('book', {include: 'author'})
   }
-});
+})

--- a/client/app/routes/login.js
+++ b/client/app/routes/login.js
@@ -1,0 +1,15 @@
+import Ember from 'ember'
+const {get, inject} = Ember
+
+export default Ember.Route.extend({
+  session: inject.service(),
+  actions: {
+    login (username, password) {
+      get(this, 'session').login(username, password)
+        .then(() => {
+          this.transitionTo('index')
+        })
+        .catch(() => alert('boo'))
+    }
+  }
+})

--- a/client/app/services/session.js
+++ b/client/app/services/session.js
@@ -1,0 +1,57 @@
+import Ember from 'ember'
+import AjaxService from 'ember-ajax/services/ajax'
+import ENV from 'client/config/environment'
+const { inject, set, computed } = Ember
+
+// const CurrentUserProxy = Ember.ObjectProxy.extend(Ember.PromiseProxyMixin)
+// CurrentUserProxy[NAME_KEY] = 'current-user'
+
+export default AjaxService.extend({
+  store: inject.service(),
+  // nameNumber: inject.service(),
+  returnTo: '',
+  userId: computed.alias('currentUser.id').readOnly(),
+  isAuthenticated: computed.bool('userId'),
+
+  // currentUser: computed(function () {
+  //   return CurrentUserProxy.create({
+  //     promise: this.request('water-users/me')
+  //       .then((userJSON) => {
+  //         get(this, 'store').pushPayload('water-user', userJSON)
+  //         return get(this, 'store').peekRecord('water-user', userJSON.data.id)
+  //       })
+  //       .catch((err) => {
+  //         return err
+  //       })
+  //   })
+  // }).readOnly(),
+
+  // currentUserCINameNumbersPromise: computed('currentUser', function () {
+  //   return get(this, 'nameNumber').getCINameNumbersForEmailAddress(get(this, 'currentUser.email'))
+  //     .then(results => {
+  //       return results
+  //     })
+  //     .catch(() => '')
+  // }),
+
+  // loginPath: computed('returnTo', function () {
+  //   return get(this, 'returnTo') ? `/login?returnTo=${get(this, 'returnTo')}` : '/login'
+  // }),
+
+  login (username, password) {
+    // window.location.assign(get(this, 'loginPath'))
+    return this.post(`${ENV.apiHost}/api-auth-token`, {data: {username, password}})
+      .then(data => {
+        set(this, 'token', data.token)
+        return
+      })
+  },
+
+  logout () {
+    window.location.assign('/logout')
+  },
+
+  changePassword () {
+    window.location.assign('/change-password')
+  }
+})

--- a/client/app/templates/authors.hbs
+++ b/client/app/templates/authors.hbs
@@ -11,4 +11,12 @@
 {{/each}}
 </ul>
 
+{{add-edit-author
+  author=model.newAuthor
+  saveAuthor=(route-action 'saveAuthor')
+}}
+
+
+
+
 {{#link-to "index"}}Back{{/link-to}}

--- a/client/app/templates/authors.hbs
+++ b/client/app/templates/authors.hbs
@@ -1,7 +1,7 @@
 <h2>Authors</h2>
 
 <ul>
-{{#each model as |author|}}
+{{#each model.authors as |author|}}
   <li>{{author.name}}</li>
   <ul>
   {{#each author.books as |book|}}

--- a/client/app/templates/login.hbs
+++ b/client/app/templates/login.hbs
@@ -1,0 +1,3 @@
+{{login-form
+  login=(route-action 'login')
+}}

--- a/client/bower.json
+++ b/client/bower.json
@@ -1,8 +1,5 @@
 {
   "name": "client",
   "dependencies": {
-    "ember": "~2.7.0",
-    "ember-cli-shims": "0.1.1",
-    "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/client/ember-cli-build.js
+++ b/client/ember-cli-build.js
@@ -1,11 +1,12 @@
 /*jshint node:true*/
 /* global require, module */
-var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+const EmberApp = require('ember-cli/lib/broccoli/ember-app')
 
-module.exports = function(defaults) {
-  var app = new EmberApp(defaults, {
-    // Add options here
-  });
+module.exports = function (defaults) {
+  const app = new EmberApp(defaults, {
+    // disable ember-cli from running jshint
+    hinting: false
+  })
 
   // Use `app.import` to add additional libraries to the generated
   // output files.
@@ -20,5 +21,6 @@ module.exports = function(defaults) {
   // please specify an object with the list of modules as keys
   // along with the exports of each module as its value.
 
-  return app.toTree();
-};
+
+  return app.toTree()
+}

--- a/client/package.json
+++ b/client/package.json
@@ -38,7 +38,11 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
+    "ember-route-action-helper": "2.0.3",
     "ember-welcome-page": "^1.0.1",
     "loader.js": "^4.0.1"
+  },
+  "dependencies": {
+    "mediasuite-formelements": "git+https://github.com/mediasuitenz/mediasuite-form-elements.git#1.0.0"
   }
 }

--- a/client/package.json
+++ b/client/package.json
@@ -7,42 +7,41 @@
     "doc": "doc",
     "test": "tests"
   },
+  "repository": "",
   "scripts": {
     "build": "ember build",
     "start": "ember server",
     "test": "ember test"
   },
-  "repository": "",
-  "engines": {
-    "node": ">= 0.10.0"
-  },
-  "author": "",
-  "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.2",
-    "ember-ajax": "^2.0.1",
-    "ember-cli": "2.7.0",
-    "ember-cli-app-version": "^1.0.0",
-    "ember-cli-babel": "^5.1.6",
-    "ember-cli-dependency-checker": "^1.2.0",
-    "ember-cli-htmlbars": "^1.0.3",
-    "ember-cli-htmlbars-inline-precompile": "^0.3.1",
-    "ember-cli-inject-live-reload": "^1.4.0",
-    "ember-cli-jshint": "^1.0.0",
-    "ember-cli-qunit": "^2.0.0",
-    "ember-cli-release": "^0.2.9",
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "2.12.0",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-babel": "^5.1.7",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-eslint": "^3.0.0",
+    "ember-cli-flash": "1.3.16",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-qunit": "^3.1.0",
+    "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
-    "ember-cli-test-loader": "^1.1.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.7.0",
+    "ember-data": "^2.12.0",
     "ember-export-application-global": "^1.0.5",
-    "ember-load-initializers": "^0.5.1",
+    "ember-load-initializers": "^0.6.0",
     "ember-resolver": "^2.0.3",
     "ember-route-action-helper": "2.0.3",
-    "ember-welcome-page": "^1.0.1",
-    "loader.js": "^4.0.1"
+    "ember-source": "~2.12.0",
+    "ember-welcome-page": "^2.0.2",
+    "loader.js": "^4.2.3"
   },
   "dependencies": {
     "mediasuite-formelements": "git+https://github.com/mediasuitenz/mediasuite-form-elements.git#1.0.0"
+  },
+  "engines": {
+    "node": ">= 4"
   }
 }

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -57,6 +57,8 @@ MIDDLEWARE = [
 
 CORS_ORIGIN_ALLOW_ALL=True
 
+APPEND_SLASH=False
+
 ROOT_URLCONF = 'mysite.urls'
 
 TEMPLATES = [
@@ -76,6 +78,7 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = 'mysite.wsgi.application'
+
 
 
 # Database
@@ -135,12 +138,12 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        #'rest_framework.permissions.IsAuthenticated'
-        'rest_framework.authentication.TokenAuthentication',
-        'rest_framework.authentication.SessionAuthentication'
+        'rest_framework.permissions.IsAuthenticated'
+        # 'rest_framework.authentication.TokenAuthentication',
+        # 'rest_framework.authentication.SessionAuthentication'
     ],
     'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework.authentication.BasicAuthentication'
+        'rest_framework.authentication.TokenAuthentication'
     ],
     # jsonapi restframework config
     'PAGE_SIZE': 2,

--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework.authtoken',
     'corsheaders',
 ]
 
@@ -134,7 +135,12 @@ REST_FRAMEWORK = {
     # Use Django's standard `django.contrib.auth` permissions,
     # or allow read-only access for unauthenticated users.
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.DjangoModelPermissionsOrAnonReadOnly'
+        #'rest_framework.permissions.IsAuthenticated'
+        'rest_framework.authentication.TokenAuthentication',
+        'rest_framework.authentication.SessionAuthentication'
+    ],
+    'DEFAULT_AUTHENTICATION_CLASSES': [
+        'rest_framework.authentication.BasicAuthentication'
     ],
     # jsonapi restframework config
     'PAGE_SIZE': 2,

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -26,7 +26,8 @@ from rest_framework.permissions import IsAuthenticated
 class AuthorsSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Author
-        fields = ['name', 'books']
+        fields = ('name', 'books')
+        read_only_fields = ('books',)
 
     included_serializers = {
         'books': 'mysite.urls.BooksSerializer'
@@ -41,6 +42,7 @@ class BooksSerializer(serializers.HyperlinkedModelSerializer):
         'author': 'mysite.urls.AuthorsSerializer',
         'genre': 'mysite.urls.GenresSerializer'
     }
+
 
 class GenresSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -19,6 +19,7 @@ from books.models import Book, Author, Genre
 
 from rest_framework import routers, viewsets
 from rest_framework_json_api import serializers
+from rest_framework.authtoken.views import obtain_auth_token
 
 class AuthorsSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
@@ -67,6 +68,7 @@ router.register(r'genres', GenreViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
+    url(r'^api-auth-token/', obtain_auth_token),
     url(r'^books/', include('books.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls')),

--- a/mysite/urls.py
+++ b/mysite/urls.py
@@ -20,6 +20,8 @@ from books.models import Book, Author, Genre
 from rest_framework import routers, viewsets
 from rest_framework_json_api import serializers
 from rest_framework.authtoken.views import obtain_auth_token
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
 
 class AuthorsSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
@@ -53,9 +55,11 @@ class AuthorViewSet(viewsets.ModelViewSet):
     queryset = Author.objects.all()
     serializer_class = AuthorsSerializer
 
+
 class BookViewSet(viewsets.ModelViewSet):
     queryset = Book.objects.all()
     serializer_class = BooksSerializer
+
 
 class GenreViewSet(viewsets.ModelViewSet):
     queryset = Genre.objects.all()
@@ -68,7 +72,7 @@ router.register(r'genres', GenreViewSet)
 
 urlpatterns = [
     url(r'^', include(router.urls)),
-    url(r'^api-auth-token/', obtain_auth_token),
+    url(r'^api-auth-token', obtain_auth_token),
     url(r'^books/', include('books.urls')),
     url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls')),


### PR DESCRIPTION
Three commits in this one:
- Pluralises the model name in the json-api 'type' attribute
- Handles model validation errors returned from Django in the Ember adapter (identical to that implemented in Water)
- Has read-only fields in the Django Author Serializer to allow us to create a model without providing all the related models